### PR TITLE
Support more than 1 card per folder

### DIFF
--- a/tonuino_cards_manager/_config.py
+++ b/tonuino_cards_manager/_config.py
@@ -60,6 +60,7 @@ CARD_SCHEMA = {
         },
         "from_song": {"type": "integer", "minimum": 1},
         "to_song": {"type": "integer", "minimum": 1},
+        "dest_folder": {"type": "integer", "minimum": 1, "maximum": 99},
     },
     "required": ["source"],
     "additionalProperties": False,
@@ -103,8 +104,9 @@ class Config:
             self.cards[int(cardno)] = carddc
 
         # Check if card keys are numbered consecutively
-        cardamount = len(self.cards)
         cardset = set(self.cards)
+        cardset = {n for n in cardset if n < 100}
+        cardamount = len(cardset)
         cardtargetlayout = set(range(1, cardamount + 1))
         if cardset != cardtargetlayout:
             logging.critical(

--- a/tonuino_cards_manager/main.py
+++ b/tonuino_cards_manager/main.py
@@ -76,30 +76,30 @@ def main() -> None:
         card_audio_length = card.process_card(
             args.destination, config.sourcebasedir, config.filenametype
         )
+        if sum(card_audio_length) > 0:
+            # Create card bytecode for this directory
+            card_bytecode = card.create_card_bytecode(
+                cookie=config.cardcookie,
+                version=config.version,
+                directory=card.no,
+                mode=card.mode,
+                extra1=card.extra1,
+                extra2=card.extra2,
+            )
 
-        # Create card bytecode for this directory
-        card_bytecode = card.create_card_bytecode(
-            cookie=config.cardcookie,
-            version=config.version,
-            directory=card.no,
-            mode=card.mode,
-            extra1=card.extra1,
-            extra2=card.extra2,
-        )
+            # Add card to QR code generation
+            qrdata.append(f"{card_bytecode};{card_description}")
 
-        # Add card to QR code generation
-        qrdata.append(f"{card_bytecode};{card_description}")
-
-        # Extract content of card
-        if card_description_detailed:
-            card_description_qr = card_description_detailed
-        else:
-            card_description_qr = card_description_generic
-        card_total_audio_length_str = str(timedelta(seconds=sum(card_audio_length)))
-        # Add card to table of contents
-        toc_list.append(
-            [cardno, card_description_qr, len(card_audio_length), card_total_audio_length_str]
-        )
+            # Extract content of card
+            if card_description_detailed:
+                card_description_qr = card_description_detailed
+            else:
+                card_description_qr = card_description_generic
+            card_total_audio_length_str = str(timedelta(seconds=sum(card_audio_length)))
+            # Add card to table of contents
+            toc_list.append(
+                [cardno, card_description_qr, len(card_audio_length), card_total_audio_length_str]
+            )
 
     # Delete directories that have not been configured
     if args.force:


### PR DESCRIPTION
Fixes #2 

After the discussion, I started to implement concept 1. This branch is not ready for merging yet.

This means no changes for cards with numbers 1-99. The concept is fully backward compatible.

I added:
* Possibility to define cards with numbers > 99.
* Cards > 99 need to have the option dest_folder (is checked). 
* dest_folder needs to be 1-99 (is checked).
* the option dest_folder is ignored for card numbers 1-99 
* The dest_folder needs to exist when the card is processed (is checked)
* For the card single mode or a from-to mode needs to be defined (is checked)


The playing mode of the dest_folder is not checked yet. And I just copy the given from-to numbers. With more then one card per folder this is not convenient.


Things to add:
* Check the playing mode of the dest_folder
* Handle from-to numbers nicely
* Test-Cases
* add-on: Create empty folder if necessary

This branch is not ready for merging yet, I will continue to work on it. Comments welcome.
